### PR TITLE
Use gophercloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ _testmain.go
 *.test
 *.prof
 terraform.*
+crash.log
+Godeps/Readme
+Godeps/_workspace

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,84 @@
+{
+	"ImportPath": "github.com/tkak/terraform-provider-conoha",
+	"GoVersion": "go1.4",
+	"Packages": [
+		"./..."
+	],
+	"Deps": [
+		{
+			"ImportPath": "github.com/hashicorp/hcl",
+			"Rev": "96d5b404339b804b7209cc8e2a3854e3388f88d2"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/terraform/config",
+			"Comment": "v0.3.1-554-gef1f2d5",
+			"Rev": "ef1f2d5e716cef7c47c18c8359f3c10b49cf0e97"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/terraform/depgraph",
+			"Comment": "v0.3.1-554-gef1f2d5",
+			"Rev": "ef1f2d5e716cef7c47c18c8359f3c10b49cf0e97"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/terraform/digraph",
+			"Comment": "v0.3.1-554-gef1f2d5",
+			"Rev": "ef1f2d5e716cef7c47c18c8359f3c10b49cf0e97"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/terraform/flatmap",
+			"Comment": "v0.3.1-554-gef1f2d5",
+			"Rev": "ef1f2d5e716cef7c47c18c8359f3c10b49cf0e97"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/terraform/helper/multierror",
+			"Comment": "v0.3.1-554-gef1f2d5",
+			"Rev": "ef1f2d5e716cef7c47c18c8359f3c10b49cf0e97"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/terraform/helper/schema",
+			"Comment": "v0.3.1-554-gef1f2d5",
+			"Rev": "ef1f2d5e716cef7c47c18c8359f3c10b49cf0e97"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/terraform/plugin",
+			"Comment": "v0.3.1-554-gef1f2d5",
+			"Rev": "ef1f2d5e716cef7c47c18c8359f3c10b49cf0e97"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/terraform/rpc",
+			"Comment": "v0.3.1-554-gef1f2d5",
+			"Rev": "ef1f2d5e716cef7c47c18c8359f3c10b49cf0e97"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/terraform/terraform",
+			"Comment": "v0.3.1-554-gef1f2d5",
+			"Rev": "ef1f2d5e716cef7c47c18c8359f3c10b49cf0e97"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/yamux",
+			"Rev": "9feabe6854fadca1abec9cd3bd2a613fe9a34000"
+		},
+		{
+			"ImportPath": "github.com/mitchellh/copystructure",
+			"Rev": "d8968bce41ab42f33aeb143afa95e331cb1ba886"
+		},
+		{
+			"ImportPath": "github.com/mitchellh/mapstructure",
+			"Rev": "740c764bc6149d3f1806231418adb9f52c11bcbf"
+		},
+		{
+			"ImportPath": "github.com/mitchellh/reflectwalk",
+			"Rev": "9989d7067f58812d814f5a837c5cbdd31799b694"
+		},
+		{
+			"ImportPath": "github.com/racker/perigee",
+			"Comment": "v0.0.0-18-g0c00cb0",
+			"Rev": "0c00cb0a026b71034ebc8205263c77dad3577db5"
+		},
+		{
+			"ImportPath": "github.com/rackspace/gophercloud",
+			"Comment": "v1.0.0-239-g4bc0d65",
+			"Rev": "4bc0d65f88a8b60df59778baa0b10e5a76dd68c9"
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -5,8 +5,36 @@ This project is a [terraform](http://www.terraform.io/) provider for [ConoHa](ht
 
 This current version only supports a container management function.
 
-References
-==========
+## Usage
+
+Terraform file
+
+```
+variable "conoha_username" {}
+variable "conoha_password" {}
+variable "conoha_tenant" {}
+
+provider "conoha" {
+    username = "${var.conoha_username}"
+    password = "${var.conoha_password}"
+    tenant_name = "${var.conoha_tenant}"
+}
+
+resource "conoha_container" "example" {
+    name = "foo"
+}
+```
+
+Run terraform.
+
+```
+$ terraform apply \
+-var "conoha_username=${CONOHA_USERNAME}" \
+-var "conoha_password=${CONOHA_PASSWORD}" \
+-var "conoha_tenant=${CONOHA_TENANT}"
+```
+
+## References
 
 * [API Reference](https://www.conoha.jp/guide/guide.php?g=52)
 * [Writing Custom Terraform Providers](https://www.hashicorp.com/blog/terraform-custom-providers.html)

--- a/conoha/config.go
+++ b/conoha/config.go
@@ -1,43 +1,29 @@
 package conoha
 
 import (
-	"fmt"
-	"log"
-	"os"
-
-	"github.com/tkak/conoha"
+	"github.com/rackspace/gophercloud"
+	"github.com/rackspace/gophercloud/openstack"
 )
 
 type Config struct {
-	Tenant   string `mapstructure:"tenant"`
-	User     string `mapstructure:"user"`
-	Password string `mapstructure:"password"`
-	Token    string `mapstructure:"token"`
-	Endpoint string `mapstructure:"endpoint"`
+	Username   string
+	Password   string
+	TenantName string
+	Token      string
+	Endpoint   string
 }
 
-func (c *Config) Client() (*conoha.Client, error) {
-
-	if v := os.Getenv("CONOHA_TENANT"); v != "" {
-		c.Tenant = v
+func (c *Config) NewClient() (*gophercloud.ProviderClient, error) {
+	opts := gophercloud.AuthOptions{
+		IdentityEndpoint: "https://ident-r1nd1001.cnode.jp/v2.0/",
+		Username:         c.Username,
+		Password:         c.Password,
+		TenantName:       c.TenantName,
 	}
-
-	if v := os.Getenv("CONOHA_USER"); v != "" {
-		c.User = v
-	}
-
-	if v := os.Getenv("CONOHA_PASSWORD"); v != "" {
-		c.Password = v
-	}
-
-	client, err := conoha.NewClient(c.Tenant, c.User, c.Password)
-
+	provider, err := openstack.AuthenticatedClient(opts)
 	if err != nil {
-		fmt.Println("")
+		return nil, err
 	}
 
-	log.Printf("[INFO] ConoHaClient configured for user %s", c.User)
-	log.Printf("[INFO] ConoHa Endpoint configured %s", c.Endpoint)
-
-	return client, nil
+	return provider, nil
 }

--- a/conoha/provider.go
+++ b/conoha/provider.go
@@ -1,30 +1,33 @@
 package conoha
 
 import (
-	"log"
-
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/mitchellh/mapstructure"
 )
 
 // Provider returns a terraform.ResourceProvider.
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
-			"tenant": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+			"tenant_name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CONOHA_TENANT", nil),
+				Description: "A ConoHa tenant name.",
 			},
 
-			"user": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+			"username": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CONOHA_USERNAME", nil),
+				Description: "A ConoHa user name.",
 			},
 
 			"password": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CONOHA_PASSWORD", nil),
+				Description: "A ConoHa user password.",
 			},
 		},
 
@@ -37,13 +40,11 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	var config Config
-	configRaw := d.Get("").(map[string]interface{})
-	if err := mapstructure.Decode(configRaw, &config); err != nil {
-		return nil, err
+	config := Config{
+		TenantName: d.Get("tenant_name").(string),
+		Username:   d.Get("username").(string),
+		Password:   d.Get("password").(string),
 	}
 
-	log.Println("[INFO] Initializing ConoHa client")
-
-	return config.Client()
+	return config.NewClient()
 }

--- a/examples/conoha.tf
+++ b/examples/conoha.tf
@@ -1,11 +1,11 @@
-variable "conoha_user" {}
+variable "conoha_username" {}
 variable "conoha_password" {}
 variable "conoha_tenant" {}
 
 provider "conoha" {
-    user = "${var.conoha_user}"
+    username = "${var.conoha_username}"
     password = "${var.conoha_password}"
-    tenant = "${var.conoha_tenant}"
+    tenant_name = "${var.conoha_tenant}"
 }
 
 resource "conoha_container" "example" {


### PR DESCRIPTION
I'm thinking about changing ConoHa API Library from go-conoha to gophercloud, which is OpenStack Go SDK created by Rackspace.